### PR TITLE
Add --proxy setting (using http-proxy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ This will install `http-server` globally so that it may be run from the command 
 
 `-o` Open browser window after staring the server
 
+`-P` or `--proxy` Proxies all requests which can't be resolved locally to the given url. e.g.: -P http://someurl.com
+
 `-S` or `--ssl` Enable https.
 
 `-C` or `--cert` Path to ssl cert file (default: cert.pem).

--- a/bin/http-server
+++ b/bin/http-server
@@ -24,6 +24,8 @@ if (argv.h || argv.help) {
     "  -c                 Cache time (max-age) in seconds [3600], e.g. -c10 for 10 seconds.",
     "                     To disable caching, use -c-1.",
     "",
+    "  -P --proxy         Fallback proxy if the request cannot be resolved. e.g.: http://someurl.com",
+    "",
     "  -S --ssl           Enable https.",
     "  -C --cert          Path to ssl cert file (default: cert.pem).",
     "  -K --key           Path to ssl key file (default: key.pem).",
@@ -37,6 +39,7 @@ var port = argv.p || parseInt(process.env.PORT, 10),
     host = argv.a || '0.0.0.0',
     log = (argv.s || argv.silent) ? (function () {}) : console.log,
     ssl = !!argv.S || !!argv.ssl,
+    proxy = argv.P || argv.proxy,
     requestLogger;
 
 if (!argv.s && !argv.silent) {
@@ -62,7 +65,8 @@ function listen(port) {
     showDir: argv.d,
     autoIndex: argv.i,
     ext: argv.e || argv.ext,
-    logFn: requestLogger
+    logFn: requestLogger,
+    proxy: proxy
   };
 
   if (argv.cors) {
@@ -87,6 +91,10 @@ function listen(port) {
       + ((ssl) ? ' through'.yellow + ' https'.cyan : '')
       + ' on: '.yellow
       + uri.cyan);
+
+    if (typeof proxy === 'string') {
+      log('Unhandled requests will be served from: ' + proxy);
+    }
 
     log('Hit CTRL-C to stop the server');
     if (argv.o) {

--- a/lib/http-server.js
+++ b/lib/http-server.js
@@ -1,7 +1,8 @@
 var fs = require('fs'),
     util = require('util'),
     union = require('union'),
-    ecstatic = require('ecstatic');
+    ecstatic = require('ecstatic'),
+    httpProxy = require('http-proxy');
 
 var HTTPServer = exports.HTTPServer = function (options) {
   options = options || {};
@@ -47,11 +48,22 @@ var HTTPServer = exports.HTTPServer = function (options) {
         cache: this.cache,
         showDir: this.showDir,
         autoIndex: this.autoIndex,
-        defaultExt: this.ext
+        defaultExt: this.ext,
+        handleError: typeof options.proxy !== 'string'
       })
     ]),
     headers: this.headers || {}
   };
+
+  if (typeof options.proxy === 'string') {
+    var proxy = httpProxy.createProxyServer({});
+    serverOptions.before.push(function (req, res) {
+      proxy.web(req, res, {
+        target: options.proxy,
+        changeOrigin: true
+      });
+    });
+  }
 
   if (options.https) {
     serverOptions.https = options.https;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "colors": "1.0.3",
     "optimist": "0.6.x",
     "union": "~0.4.3",
-    "ecstatic": "~0.6.0",
+    "ecstatic": "~0.6.1",
+    "http-proxy": "^1.8.1",
     "portfinder": "0.2.x",
     "opener": "~1.4.0"
   },

--- a/test/http-server-test.js
+++ b/test/http-server-test.js
@@ -65,6 +65,54 @@ vows.describe('http-server').addBatch({
         assert.equal(res.headers['access-control-allow-origin'], '*');
         assert.equal(res.headers['access-control-allow-credentials'], 'true');
       }
+    },
+    'When http-server is proxying from 8081 to 8080': {
+      topic: function () {
+        var proxyServer = httpServer.createServer({
+          proxy: 'http://127.0.0.1:8080/',
+          root: path.join(__dirname, 'fixtures')
+        });
+        proxyServer.listen(8081);
+        this.callback(null, proxyServer);
+      },
+      'it should serve files from the proxy server root directory': {
+        topic: function () {
+          request('http://127.0.0.1:8081/root/file', this.callback);
+        },
+        'status code should be the enpoint code 200': function (res) {
+          assert.equal(res.statusCode, 200);
+        },
+        'and file content': {
+          topic: function (res, body) {
+            var self = this;
+            fs.readFile(path.join(root, 'file'), 'utf8', function (err, data) {
+              self.callback(err, data, body);
+            });
+          },
+          'should match content of the served file': function (err, file, body) {
+            assert.equal(body.trim(), file.trim());
+          }
+        }
+      },
+      'it should fallback to the proxied server': {
+        topic: function () {
+          request('http://127.0.0.1:8081/file', this.callback);
+        },
+        'status code should be the enpoint code 200': function (res) {
+          assert.equal(res.statusCode, 200);
+        },
+        'and file content': {
+          topic: function (res, body) {
+            var self = this;
+            fs.readFile(path.join(root, 'file'), 'utf8', function (err, data) {
+              self.callback(err, data, body);
+            });
+          },
+          'should match content of the proxied served file': function (err, file, body) {
+            assert.equal(body.trim(), file.trim());
+          }
+        }
+      }
     }
   }
 }).export(module);


### PR DESCRIPTION
This pull request implements the same feautre like https://github.com/nodeapps/http-server/pull/133 .  
However it uses the `http-proxy` module instead of the `proxy-middleware` module.

From https://github.com/nodeapps/http-server/pull/133 :

This pull request would add a new feature to *http-server*.  
It is called **proxy** as it uses the *proxy-middleware* module to redirect unresolvable requests to a given url. 

Checkout the pull request:

```
git clone https://github.com/jantimon/http-server.git --branch feature/node-http-proxy --single-branch --depth 1
cd http-server
npm install
```

Example usage

```
node bin/http-server -P http://blog.nodejitsu.com/
```

[Open http://localhost:8080/img/](http://localhost:8080/img/) and it will resolve `http-server/public/img` just like before.

![index_of__img_](https://cloud.githubusercontent.com/assets/4113649/6472844/7725d9fa-c1f5-11e4-95d8-aa9433703672.png)

Next [navigate to http://localhost:8080/nodejitsu-joins-godaddy/](http://localhost:8080/nodejitsu-joins-godaddy/) - as it cannot find the folder `nodejitsu-joins-godaddy/` locally it will redirect the requests to the proxy address and you will see the blog post:

![proxyexample](https://cloud.githubusercontent.com/assets/4113649/6472785/23137584-c1f5-11e4-8362-33aad602f05f.png)

My motivation behind this pull request is **debugging live pages**  
Lets say you have a web page running on `http://somepage.com/` and there is a bug in `http://somepage.com/example.js`. All you have to do is placing a patched or debug version of example.js in a folder and start up http-server with a proxy to http://somepage.com and open http://localhost:8080

The proxy feature works even better if you disable the directory listening `-d false` but this is not required.
